### PR TITLE
Activates Tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,42 +1,18 @@
-var gulp   = require('gulp');
-var jshint = require('gulp-jshint');
-var karma = require('gulp-karma');
-var jasmine = require('gulp-jasmine');
+var gulp     = require('gulp');
+var jshint   = require('gulp-jshint');
+var Server   = require('karma').Server;
 
-var testFiles = [
-  'public/bower_components/angular/angular.js',
-  'public/bower_components/angular-route/angular-route.js',
-  'public/bower_components/angular-mocks/angular-mocks.js',
-  'public/lib/*.js',
-  'public/js/*.js',
-  'spec/*.js'
-];
-
-// tun tests once
-gulp.task('test', function() {
-	return gulp.src(testFiles)
-		.pipe(karma({
-			configFile: 'conf/karma.conf.js',
-			action: 'run'
-		}))
-		.on('error', function(err) {
-			// failed tests cause gulp to exit non-zero
-			throw err;
-		})
-		.pipe(jasmine());
+gulp.task('test', function (done) {
+  new Server({
+    configFile: __dirname + '/karma.conf.js',
+    singleRun: true
+  }, done).start();
 });
 
-// continuously run tests on change
-gulp.task('watch', function() {
-  gulp.src(testFiles)
-    .pipe(karma({
-        configFile: 'conf/karma.conf.js',
-        action: 'watch'
-    })).on('error', function(err) {
-        // failed tests cause gulp to exit non-zero
-        throw err;
-    })
-    .pipe(jasmine());
+gulp.task('watch', function (done) {
+  new Server({
+    configFile: __dirname + '/karma.conf.js'
+  }, done).start();
 });
 
 gulp.task('lint', function() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,70 @@
+// Karma configuration
+// Generated on Wed Aug 19 2015 19:48:01 GMT-0400 (EDT)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'public/bower_components/angular/angular.js',
+      'public/bower_components/angular-mocks/angular-mocks.js',
+      'public/bower_components/angular-route/angular-route.js',
+      'public/lib/*.js',
+      'public/js/*.js',
+      'spec/**/*.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  })
+}


### PR DESCRIPTION
### Description
* Previous to this commit, the tests didn't run at all. This was due to
  a misconfiguration of karma and jasmine.
* Deletes gulp-jasmine and gulp-karma
    * As is [outlined here](https://github.com/karma-runner/gulp-karma),
      gulp does not require the now-dead gulp-karma plugin because gulp
      directly invokes karma's public API. Hence, I deleted the
      gulp-karma plugin.
    * jasmine is invoked via karma.js.conf, so there is no need for the
      gulp-jasmine plugin.
* Greatly simplifies Gulpfile
    * Much of the test configuration has been moved to karma.js.conf.
    * Gulpfile now directly invokes karma, which is configured to use
      jasmine.
* Replaces old gulp tasks "test" and "watch" with new ones.
* *NOTE*: `gulp lint`, which is outside of the scope of this PR, throws
  errors galore. I will address that problem in a separate PR.

### Test
* Run `gulp test`. **Assert that** it passes.
* Run `gulp watch`.
  * **Assert that** it passes.
  * Break something. **Assert that** `gulp watch` reports the problem.
  * Fix it. **Assert that** `gulp watch` is happy again.